### PR TITLE
CI checks out the repo using a GH app token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on:
@@ -22,48 +23,47 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Read Configuration
-      uses: hashicorp/vault-action@v3
-      id: vault
-      with:
-        url: ${{ env.VAULT_ADDR }}
-        token: ${{ secrets.VAULT_TOKEN }}
-        secrets: |
-          kv/data/github  "SSH_PRIVATE_KEY"     | SSH_PRIVATE_KEY;
-
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: '20.x'
-
-    - name: Clean generated code
-      run: rm -rf pkg
-
-    - name: Set up Homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-
-    - name: Install Buf
-      run: brew install bufbuild/buf/buf
-
-    - name: Install protoc
-      run: |
-        brew install protobuf@3
-        brew link --overwrite protobuf@3
-
-    - name: Yarn Install
-      run: yarn install
-
-    - name: Generate
-      run: yarn gen
-
-    - name: Commit changes
-      if: github.event_name == 'workflow_dispatch'
-      uses: EndBug/add-and-commit@v7
-      with:
-        default_author: github_actions
-        add: 'src'
+      -
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CODEGEN_APP_ID }}
+          private-key: ${{ secrets.CODEGEN_APP_KEY }}
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      -
+        name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      -
+        name: Clean generated code
+        run: rm -rf pkg
+      -
+        name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      -
+        name: Install Buf
+        run: brew install bufbuild/buf/buf
+      -
+        name: Install protoc
+        run: |
+          brew install protobuf@3
+          brew link --overwrite protobuf@3
+      -
+        name: Yarn Install
+        run: yarn install
+      -
+        name: Generate
+        run: yarn gen
+      -
+        name: Commit changes
+        if: github.event_name == 'workflow_dispatch'
+        uses: EndBug/add-and-commit@v7
+        with:
+          default_author: github_actions
+          add: 'src'


### PR DESCRIPTION
The app is allowed to bypass branch protection rules in the repo. This setup ensures that branch protection is enforced for human contributors, but the automated workflow can generate code and commit it to main.