### PR TITLE
Bump to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aserto/node-directory-store",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Node gRPC bindings for the Aserto directory store",
   "scripts": {
     "gen": "rm -rf src && buf generate --include-imports ${BUF_PATH:-buf.build/aserto-dev/directory-store} && rm -rf src/gen/cjs && tsc",


### PR DESCRIPTION
pb-directory-store has advanced to v0.2.0 with the introduction of the Controller service.